### PR TITLE
Issue 65 + 66

### DIFF
--- a/R/question_parsers.R
+++ b/R/question_parsers.R
@@ -23,11 +23,12 @@ parse_all_questions <- function(surv_obj){
 # New function per #21 to grab all Q+A info at once
 parse_question_info <- function(ques){
 
-  # get top-level info
+  # Fixes issue 65 - this was caused by an image/presentation type not having a value for 'heading'
   if (is.null(ques$headings[[1]]$heading)){
     ques$headings[[1]]$heading <- ""
   }
 
+  # get top-level info
   q_info <- tibble::tibble(heading = ques$headings[[1]]$heading,
                  question_id = ques$id,
                  question_type = ques$family,

--- a/R/question_parsers.R
+++ b/R/question_parsers.R
@@ -24,6 +24,10 @@ parse_all_questions <- function(surv_obj){
 parse_question_info <- function(ques){
 
   # get top-level info
+  if (is.null(ques$headings[[1]]$heading)){
+    ques$headings[[1]]$heading <- ""
+  }
+
   q_info <- tibble::tibble(heading = ques$headings[[1]]$heading,
                  question_id = ques$id,
                  question_type = ques$family,

--- a/R/question_parsers.R
+++ b/R/question_parsers.R
@@ -25,7 +25,7 @@ parse_question_info <- function(ques){
 
   # Fixes issue 65 - this was caused by an image/presentation type not having a value for 'heading'
   if (is.null(ques$headings[[1]]$heading)){
-    ques$headings[[1]]$heading <- ""
+    ques$headings[[1]]$heading <- NA_character_
   }
 
   # get top-level info


### PR DESCRIPTION
Sorry for the storm of pull requests!

It seems that you'll be able to test that the `NA` fix works for a survey that you have access to for #66, and for #65,  you can recreate by adding an image to a page on your survey. In the example that I used for debugging, there was intro text followed by an image.

I'm fairly confident that the culprit is `surv_obj$pages[[1]]$questions[[2]]$$headings[[1]]$heading` (may need to change some of the indexing but wanted to provide so it's easy to identify).  