### PR TITLE
Allow for 401Unauthorized failure during login

### DIFF
--- a/R/browse_surveys.R
+++ b/R/browse_surveys.R
@@ -60,11 +60,12 @@ browse_surveys <- function(per_page = 100,
                    config = h,
                    httr::user_agent("http://github.com/tntp/surveymonkey"),
                    query = b)
+  httr::stop_for_status(out)
+
   message(paste0("You have ", out$headers$`x-ratelimit-app-global-day-remaining`, " requests left today before you hit the limit"))
   if(as.numeric(out$headers$`x-ratelimit-app-global-day-remaining`) %% 20 == 0){ # announce reset time every 20 hits to API
     message(paste0("Your daily request limit will reset in ", out$headers$`X-Ratelimit-App-Global-Day-Reset`, " seconds"))
   }
-  httr::stop_for_status(out)
   parsed_content <- httr::content(out, as = 'parsed')
   sl <- dplyr::bind_rows(parsed_content$data)
   dplyr::select(sl, title, id, url = href, nickname)


### PR DESCRIPTION
If the user cannot actually login with the given token (for example, a typo when setting up the `options()` call :P) then the SM API might return 401 unauthorized. In this situation, the headers will not contain the rate limit info, and the function will bomb out at line 63 because it's missing an argument:

```
You have requests left today before you hit the limit
Error in if (as.numeric(out$headers$x-ratelimit-app-global-day-remaining)%%20 == :
argument is of length zero
```

Simple fix is to check the return of the API call before trying to do anything with it.