### PR TITLE
Fix for manually specifying oauth token

### DIFF
--- a/R/get_responses.R
+++ b/R/get_responses.R
@@ -134,7 +134,8 @@ get_responses <- function(
                            start_modified_at,
                            end_modified_at,
                            sort_order,
-                           sort_by)
+                           sort_by,
+                           oauth_token = oauth_token)
     responses <- c(responses, rnext)
   }
   responses


### PR DESCRIPTION
Adds option to `get_responses()` where if a user manually specifies an `oauth_token`, the default isn't to pull from the .Rprofile, but to use the `oauth_token` already specified.