### PR TITLE
Support for Issue #57

### DIFF
--- a/R/assemble.R
+++ b/R/assemble.R
@@ -51,6 +51,12 @@ parse_survey <- function(surv_obj, oauth_token = getOption('sm_oauth_token'), ..
   # Issue #73 - API added choice_metadata for certain question types.
   # Need to investigate further, but as of 11/2021, the addition is preventing parse_survey() from working.
   x$choice_metadata <- NULL
+  browser()
+  # Star Ranking: If rating labels are not used, choice_text appears blank.
+  # - Need to recode so that choice_text is choice_position
+  x <- x %>%
+    mutate(choice_text = case_when(choice_text == "" & question_type == "matrix" & question_subtype == "rating" ~ as.character(choice_position),
+                                   TRUE ~ choice_text))
 
 
   #If question type = Multiple Choice, include choice text + ID in the combined new columns

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -51,8 +51,9 @@ parse_survey <- function(surv_obj, oauth_token = getOption('sm_oauth_token'), ..
   # Issue #73 - API added choice_metadata for certain question types.
   # Need to investigate further, but as of 11/2021, the addition is preventing parse_survey() from working.
   x$choice_metadata <- NULL
-  browser()
-  # Star Ranking: If rating labels are not used, choice_text appears blank.
+
+  # Issue #57 - Star Ranking
+  # - If rating labels are not used, choice_text appears blank.
   # - Need to recode so that choice_text is choice_position
   x <- x %>%
     mutate(choice_text = case_when(choice_text == "" & question_type == "matrix" & question_subtype == "rating" ~ as.character(choice_position),


### PR DESCRIPTION
There are many ways to set up star rating questions from the SurveyMonkey UI, including using different objects/emojis (stars, smileys, etc.). There is also the option to use labels, which is sometimes not necessary since a respondent will usually understand if they are giving something 1 to 5 stars. When labels aren't used, we have to pass through the `choice_position` variable as the response option, since they currently come through the API as an empty string (i.e., `""`). 

