### PR TITLE
namespace for dplyr::mutate in assemble

### DIFF
--- a/R/assemble.R
+++ b/R/assemble.R
@@ -74,7 +74,7 @@ parse_survey <- function(surv_obj, oauth_token = getOption('sm_oauth_token'), ..
 
   x$combined_q_heading <- apply(x %>%
                                   dplyr::select(heading, row_text, col_text, other_text) %>%
-                                  mutate(row_text = ifelse(row_text == "", NA, row_text)),
+                                  dplyr::mutate(row_text = ifelse(row_text == "", NA, row_text)),
                                 1,
                                 function(x) paste(stats::na.omit(x), collapse= " - ")
   )


### PR DESCRIPTION
- missing namespace for dplyr mutate function caused breaking change

Couldn't see an obvious way to add a test for this, if you have any suggestions for how I could start adding more tests I am happy to do so.