### PR TITLE
feat: Allow duplicates to be dealt with in parse_survey

### DIFF
--- a/R/assemble.R
+++ b/R/assemble.R
@@ -263,7 +263,7 @@ contains_duplicates <- function(x) {
 
 # @param x a data.frame
 # @return a logical vector of the duplicated rows
-find_duplicates = function(x) {
+find_duplicates <- function(x) {
   duplicated(dplyr::select_if(x, is.atomic))
 }
 

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -291,7 +291,7 @@ duplicate_keep <- function(x) {
 }
 
 # Deal with duplicate data by throwing an error
-duplicate_error = function(x) {
+duplicate_error <- function(x) {
   # There should not be duplicate rows here, but putting this here in case of oddities like #27
   assertthat::assert_that(!contains_duplicates(x),
     msg = paste0(

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -40,7 +40,7 @@ parse_survey <- function(
   # so can't hard-code. Thus squash message
   x <- suppressMessages(dplyr::full_join(question_combos, responses))
 
-  # ref: issue #72
+  # ref: issue #74
   # assertion stops function from returning anything in the case of duplicates
   # to deal with this add parameter fix_duplicate where default behaviour is to error, but
   # can be set to allow the function to continue and return.

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -270,9 +270,10 @@ find_duplicates <- function(x) {
 # @param x a data.frame
 duplicate_drop <- function(x) {
   ix_dupes <- find_duplicates(x)
-  if (sum(ix_dupes) > 0) {
+  n_dupes <- sum(ix_dupes)
+  if (n_dupes > 0) {
     warning(
-      "There are duplicate responses, duplicates are dropped in
+      "There are ", n_dupes, " duplicate responses, duplicates are dropped in
       the results. Set fix_duplicates = 'keep' to retain them."
     )
   }
@@ -282,8 +283,9 @@ duplicate_drop <- function(x) {
 # @param x a data.frame
 duplicate_keep <- function(x) {
   if (contains_duplicates(x)) {
+    n_dupes <- sum(find_duplicates(x))
     warning(
-      "There are duplicate responses, duplicates are retained in
+      "There are ", n_dupes, " duplicate responses, duplicates are retained in
       the results. Set fix_duplicates = 'drop' to remove them."
     )
   }

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -257,7 +257,7 @@ de_duplicate_names <- function(x) {
 # does a data frame contain duplicate rows
 # @param x a data.frame
 # @return logical, TRUE if there are any duplicates in the data.frame
-contains_duplicates = function(x) {
+contains_duplicates <- function(x) {
   sum(find_duplicates(x)) > 0
 }
 

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -268,8 +268,8 @@ find_duplicates <- function(x) {
 }
 
 # @param x a data.frame
-duplicate_drop = function(x) {
-  ix_dupes = find_duplicates(x)
+duplicate_drop <- function(x) {
+  ix_dupes <- find_duplicates(x)
   if (sum(ix_dupes) > 0) {
     warning(
       "There are duplicate responses, duplicates are dropped in

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -44,13 +44,13 @@ parse_survey <- function(
   # assertion stops function from returning anything in the case of duplicates
   # to deal with this add parameter fix_duplicate where default behaviour is to error, but
   # can be set to allow the function to continue and return.
-  fix_duplicates = match.arg(fix_duplicates)
+  fix_duplicates <- match.arg(fix_duplicates)
   if (fix_duplicates == "error") {
-    x = duplicate_error(x)
+    x <- duplicate_error(x)
   } else if (fix_duplicates == "keep") {
-    x = duplicate_keep(x)
+    x <- duplicate_keep(x)
   } else {
-    x = duplicate_drop(x)
+    x <- duplicate_drop(x)
   }
 
 

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -280,7 +280,7 @@ duplicate_drop <- function(x) {
 }
 
 # @param x a data.frame
-duplicate_keep = function(x) {
+duplicate_keep <- function(x) {
   if (contains_duplicates(x)) {
     warning(
       "There are duplicate responses, duplicates are retained in

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -295,7 +295,7 @@ duplicate_error = function(x) {
   # There should not be duplicate rows here, but putting this here in case of oddities like #27
   assertthat::assert_that(!contains_duplicates(x),
     msg = paste0(
-      "There are duplicated rows in the responses, maybe a situation like #27\n",
+      "There are duplicated rows in the responses.\n",
       "To proceed and retain duplicates, re-run this function with fix_duplicates = 'keep'\n",
       "To proceed with dropped duplicates, re-run with fix_duplicates = 'drop'\n",
       "If this is unexpected - ",

--- a/man/parse_survey.Rd
+++ b/man/parse_survey.Rd
@@ -4,7 +4,12 @@
 \alias{parse_survey}
 \title{Take a survey object and parses it into a tidy data.frame.}
 \usage{
-parse_survey(surv_obj, oauth_token = get_token(), ...)
+parse_survey(
+  surv_obj,
+  oauth_token = get_token(),
+  ...,
+  fix_duplicates = c("error", "drop", "keep")
+)
 }
 \arguments{
 \item{surv_obj}{a survey, the result of a call to \code{fetch_survey_obj}.}
@@ -14,6 +19,10 @@ parse_survey(surv_obj, oauth_token = get_token(), ...)
 
 \item{...}{additional arguments to pass on to \code{get_responses}.  See the documentation
 \code{?get_responses} where these arguments are listed.}
+
+\item{fix_duplicates}{character if 'error', the default detection of duplicate data will result
+in an error being raised, otherwise allow the function to return. If 'keep' duplicate results
+will be retained, if 'drop' duplicates will be removed from the results.}
 }
 \value{
 a data.frame (technically a \code{tibble}) with clean responses, one line per respondent.

--- a/tests/testthat/test-assemble.R
+++ b/tests/testthat/test-assemble.R
@@ -1,5 +1,5 @@
-no_dupes = cars[1, ]
-dupes = rbind(no_dupes, no_dupes)
+no_dupes <- cars[1, ]
+dupes <- rbind(no_dupes, no_dupes)
 
 test_that("detect duplication", {
   expect_true(contains_duplicates(dupes))

--- a/tests/testthat/test-assemble.R
+++ b/tests/testthat/test-assemble.R
@@ -1,0 +1,26 @@
+no_dupes = cars[1, ]
+dupes = rbind(no_dupes, no_dupes)
+
+test_that("detect duplication", {
+  expect_true(contains_duplicates(dupes))
+  expect_false(contains_duplicates(no_dupes))
+})
+
+test_that("keep duplication", {
+  expect_warning(res <- duplicate_keep(dupes))
+  expect_identical(res, dupes)
+  expect_warning(res <- duplicate_keep(no_dupes), NA) # expect no warning
+  expect_identical(res, no_dupes)
+})
+
+test_that("drop duplication", {
+  expect_warning(res <- duplicate_drop(dupes))
+  expect_identical(res, no_dupes)
+  expect_warning(res <- duplicate_keep(no_dupes), NA) # expect no warning
+  expect_identical(res, no_dupes)
+})
+
+test_that("error on duplicates", {
+  expect_error(duplicate_error(dupes))
+  expect_error(duplicate_error(no_dupes), NA) # expect no error
+})


### PR DESCRIPTION
Looks to address #74 by allowing `parse_survey` to proceed even if duplicate data are found.
The existing solution errors as a result of `{assertthat}` and has no escape hatch.

This PR adds a parameter to `parse_survey`, `fix_duplicates`, which defaults to the same error behaviour as is currently present with an expanded message. But also allows the user to specify that duplicates are kept or dropped as part of the processing of survey responses. In each case if duplicates are found a warning will be presented.

- test: Add tests for functions dealing with duplicates
- default is to retain the error behaviour before